### PR TITLE
Implement hide author slug feature for security

### DIFF
--- a/assets/js/admin-page.js
+++ b/assets/js/admin-page.js
@@ -46,6 +46,7 @@
       // Place fields into "Security" tab
       $('.change-login-url').appendTo('.fields-security tbody');
       $('.custom-login-slug').appendTo('.fields-security .change-login-url .asenha-subfields');
+      $('.hide-author-slug').appendTo('.fields-security tbody');
 
       // Place fields into "Utilities" tab
       $('.redirect-after-login').appendTo('.fields-utilities tbody');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -171,6 +171,13 @@ class Admin_Site_Enhancements {
 			}
 		}
 
+		// Security >> Hide Author Slug
+		if ( array_key_exists( 'hide_author_slug', $options ) && $options['hide_author_slug'] ) {
+			add_action( 'pre_get_posts', [ $security, 'alter_author_query' ], 10 );
+			add_filter( 'author_link', [ $security, 'alter_author_link' ], 10, 3 );
+			add_filter( 'rest_prepare_user', [ $security, 'alter_json_users' ], 10, 3 );
+		}
+
 		// Instantiate object for Utilities features
 		$utilities = new ASENHA\Classes\Utilities;
 

--- a/includes/setup-admin-menu-page.php
+++ b/includes/setup-admin-menu-page.php
@@ -589,6 +589,26 @@ function asenha_register_settings() {
 		)
 	);
 
+	// Hide Author Slug
+
+	$field_id = 'hide_author_slug';
+	$field_slug = 'hide-author-slug';
+
+	add_settings_field(
+		$field_id, // Field ID
+		'Hide Author Slug', // Field title
+		'asenha_render_field_checkbox_toggle', // Callback to render field with custom arguments in the array below
+		ASENHA_SLUG, // Settings page slug
+		'main-section', // Section ID
+		array(
+			'field_id'				=> $field_id, // Custom argument
+			'field_name'			=> ASENHA_SLUG_U . '['. $field_id .']', // Custom argument
+			'field_description'		=> 'Default is ' . get_site_url() . '/author/[username]/', // Custom argument
+			'field_options_wrapper'	=> true, // Custom argument. Add container for additional options
+			'class'					=> 'asenha-toggle security ' . $field_slug, // Custom class for the <tr> element
+		)
+	);
+
 	// Redirect After Login
 
 	$field_id = 'redirect_after_login';
@@ -848,6 +868,10 @@ function asenha_sanitize_options( $options ) {
 
 	if ( ! isset( $options['custom_login_slug'] ) ) $options['custom_login_slug'] = 'backend';
 	$options['custom_login_slug'] = ( ! empty( $options['custom_login_slug'] ) ) ? sanitize_text_field( $options['custom_login_slug'] ) : 'backend';
+	
+	// Hide Author Slug
+	if ( ! isset( $options['hide_author_slug'] ) ) $options['hide_author_slug'] = false;
+	$options['hide_author_slug'] = ( 'on' == $options['hide_author_slug'] ? true : false );
 
 	// Utilities features
 


### PR DESCRIPTION
Prevent wordpress site from being hacked by hiding user slug which can be seen via wpsite.com/author/[username]/ and wpsite.com/wp-json/wp/v2/users